### PR TITLE
Add expandable goal text toggle

### DIFF
--- a/src/components/GoalCard.jsx
+++ b/src/components/GoalCard.jsx
@@ -14,10 +14,12 @@ const STATUS_LABELS = {
 
 function GoalCard({ goal, editable = false, onSave, onDelete }) {
   const [isEditing, setIsEditing] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [form, setForm] = useState(() => mapGoalToForm(goal));
 
   useEffect(() => {
     setForm(mapGoalToForm(goal));
+    setIsExpanded(false);
   }, [goal]);
 
   const deadlineText = useMemo(() => {
@@ -69,7 +71,26 @@ function GoalCard({ goal, editable = false, onSave, onDelete }) {
       <header className="goal-header">
         <div>
           <p className="goal-type">{typeLabel}</p>
-          <h3 className="goal-text">{isEditing ? form.text : goal.text}</h3>
+          <div className="goal-text-row">
+            <h3
+              className={`goal-text ${
+                isExpanded ? 'goal-text--expanded' : 'goal-text--collapsed'
+              }`}
+            >
+              {isEditing ? form.text : goal.text}
+            </h3>
+            <button
+              type="button"
+              className="goal-text-toggle"
+              aria-label={isExpanded ? 'Collapse goal text' : 'Expand goal text'}
+              aria-expanded={isExpanded}
+              onClick={() => setIsExpanded((prev) => !prev)}
+            >
+              <span aria-hidden="true" className="goal-text-toggle__icon">
+                ▾
+              </span>
+            </button>
+          </div>
         </div>
         {editable && (
           <button

--- a/src/styles.css
+++ b/src/styles.css
@@ -309,6 +309,51 @@ textarea {
 
 .goal-text {
   margin: 0.35rem 0 0;
+  flex: 1 1 auto;
+}
+
+.goal-text-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.35rem;
+  flex-wrap: nowrap;
+}
+
+.goal-text--collapsed {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.goal-text--expanded {
+  display: block;
+}
+
+.goal-text-toggle {
+  min-height: auto;
+  padding: 0.25rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.goal-text-toggle:focus-visible {
+  outline: 2px solid var(--c-primary);
+  outline-offset: 2px;
+}
+
+.goal-text-toggle__icon {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.goal-text-toggle[aria-expanded='true'] .goal-text-toggle__icon {
+  transform: rotate(180deg);
 }
 
 .goal-meta {


### PR DESCRIPTION
## Summary
- add an expandable chevron toggle to goal cards to reveal the full goal text
- clamp goal text to a single line and rotate the chevron icon based on expansion state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfde464eb88333acb41fc230ff0984