### PR TITLE
Auto-size goal textareas

### DIFF
--- a/src/components/GoalCard.jsx
+++ b/src/components/GoalCard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 const TYPE_LABELS = {
   one: 'One-Time',
@@ -16,11 +16,29 @@ function GoalCard({ goal, editable = false, onSave, onDelete }) {
   const [isEditing, setIsEditing] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [form, setForm] = useState(() => mapGoalToForm(goal));
+  const textAreaRef = useRef(null);
+
+  const adjustTextareaHeight = () => {
+    const textarea = textAreaRef.current;
+    if (!textarea) return;
+    const { lineHeight } = window.getComputedStyle(textarea);
+    const parsedLineHeight = parseFloat(lineHeight) || 0;
+    textarea.style.height = 'auto';
+    const maxHeight = parsedLineHeight ? parsedLineHeight * 10 : textarea.scrollHeight;
+    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+    textarea.style.height = `${newHeight}px`;
+  };
 
   useEffect(() => {
     setForm(mapGoalToForm(goal));
     setIsExpanded(false);
   }, [goal]);
+
+  useEffect(() => {
+    if (isEditing) {
+      adjustTextareaHeight();
+    }
+  }, [form.text, isEditing]);
 
   const deadlineText = useMemo(() => {
     if (!goal.deadline) return 'No deadline';
@@ -112,7 +130,14 @@ function GoalCard({ goal, editable = false, onSave, onDelete }) {
         <div className="goal-edit-form">
           <label>
             Text
-            <textarea name="text" value={form.text} onChange={handleChange} rows={3} />
+            <textarea
+              ref={textAreaRef}
+              name="text"
+              value={form.text}
+              onChange={handleChange}
+              onInput={adjustTextareaHeight}
+              rows={3}
+            />
           </label>
           <label>
             Type

--- a/src/pages/NewGoal.jsx
+++ b/src/pages/NewGoal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const typeOptions = [
   { value: 'one', label: 'One-Time' },
@@ -14,12 +14,28 @@ function NewGoal({ onCreate, submitting, defaultType }) {
   const [deadline, setDeadline] = useState('');
   const [isPublic, setIsPublic] = useState(true);
   const [error, setError] = useState('');
+  const textareaRef = useRef(null);
+
+  const adjustTextareaHeight = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const { lineHeight } = window.getComputedStyle(textarea);
+    const parsedLineHeight = parseFloat(lineHeight) || 0;
+    textarea.style.height = 'auto';
+    const maxHeight = parsedLineHeight ? parsedLineHeight * 10 : textarea.scrollHeight;
+    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+    textarea.style.height = `${newHeight}px`;
+  };
 
   useEffect(() => {
     if (typeOptions.some((option) => option.value === defaultType)) {
       setType(defaultType);
     }
   }, [defaultType]);
+
+  useEffect(() => {
+    adjustTextareaHeight();
+  }, [text]);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -45,8 +61,10 @@ function NewGoal({ onCreate, submitting, defaultType }) {
         <label>
           Goal statement
           <textarea
+            ref={textareaRef}
             value={text}
             onChange={(event) => setText(event.target.value)}
+            onInput={adjustTextareaHeight}
             rows={4}
             placeholder="Ship the new onboarding flow by Friday"
             required

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,7 +65,8 @@ button {
 }
 
 textarea {
-  resize: vertical;
+  resize: none;
+  overflow-y: auto;
 }
 
 .app-shell {


### PR DESCRIPTION
## Summary
- auto-size the new goal form textarea up to ten lines for better composition
- mirror the auto-resize behavior in editable goal cards
- adjust textarea styling to disable manual resizing and rely on overflow scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe0c96c3c8333914a18036a366fc5