### PR TITLE
Adjust mobile typography scale

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -18,7 +18,7 @@ html {
 
 @media (max-width: 640px) {
   html {
-    font-size: 16px;
+    font-size: 18px;
   }
 }
 
@@ -490,8 +490,9 @@ textarea {
   }
 
   .content-area {
-    padding: 1.75rem 1.25rem 2.5rem;
+    padding: 1.5rem 1.15rem 2.25rem;
     max-width: 640px;
+    gap: 1.35rem;
   }
 
   .goal-grid {
@@ -501,6 +502,19 @@ textarea {
 
   .drawer {
     width: 86vw;
+  }
+
+  .page-header h1 {
+    font-size: 1.75rem;
+  }
+
+  .page-header p {
+    margin-top: 0.4rem;
+  }
+
+  .goal-card {
+    padding: 1.35rem;
+    gap: 0.9rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- increase the mobile root font size to 18px to match the global base size
- refine mobile spacing for the main content area, header, and cards so larger type still fits comfortably

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe0cb8a1083338a0ac60b6316326c