### PR TITLE
Add countdown displays for goal deadlines

### DIFF
--- a/src/hooks/useCountdown.js
+++ b/src/hooks/useCountdown.js
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function normalizeDeadline(deadline) {
+  if (!deadline) return null;
+  if (deadline instanceof Date) {
+    return Number.isNaN(deadline.getTime()) ? null : deadline;
+  }
+
+  if (typeof deadline === 'number' || typeof deadline === 'string') {
+    const asDate = new Date(deadline);
+    return Number.isNaN(asDate.getTime()) ? null : asDate;
+  }
+
+  if (typeof deadline.toDate === 'function') {
+    try {
+      const fromTimestamp = deadline.toDate();
+      return Number.isNaN(fromTimestamp.getTime()) ? null : fromTimestamp;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function createCountdown(targetDate, referenceDate) {
+  if (!targetDate) {
+    return null;
+  }
+
+  const diffMs = targetDate.getTime() - referenceDate.getTime();
+  const clampedDiff = Math.max(diffMs, 0);
+  const totalSeconds = Math.floor(clampedDiff / 1000);
+
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return {
+    days: days > 0 ? days : null,
+    hours,
+    minutes,
+    seconds,
+    totalSeconds,
+    isExpired: diffMs <= 0,
+  };
+}
+
+export default function useCountdown(deadline) {
+  const targetDate = useMemo(() => normalizeDeadline(deadline), [deadline]);
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    if (!targetDate) return undefined;
+
+    setNow(new Date());
+    const intervalId = setInterval(() => {
+      setNow(new Date());
+    }, 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [targetDate]);
+
+  return useMemo(() => createCountdown(targetDate, now), [targetDate, now]);
+}
+
+export function formatCountdown(countdown) {
+  if (!countdown) return '';
+
+  const { days, hours, minutes, seconds } = countdown;
+  const parts = [];
+
+  if (days != null) {
+    parts.push(`${days}d`);
+  }
+
+  const pad = (value) => String(value).padStart(2, '0');
+
+  parts.push(`${pad(hours)}h`);
+  parts.push(`${pad(minutes)}m`);
+  parts.push(`${pad(seconds)}s`);
+
+  return parts.join(' ');
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -364,6 +364,14 @@ textarea {
   color: rgba(10, 10, 10, 0.7);
 }
 
+.goal-countdown {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 .goal-edit-form {
   display: grid;
   gap: 0.75rem;
@@ -391,6 +399,16 @@ textarea {
   display: grid;
   gap: 1rem;
   max-width: 520px;
+}
+
+.deadline-preview {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(10, 10, 10, 0.7);
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .goal-form label {


### PR DESCRIPTION
## Summary
- add a reusable countdown hook that normalizes deadline inputs and formats the remaining time
- display the live deadline countdown on goal cards and in the new goal form preview with consistent styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe0cc09648333a0433758add9fb90