### PR TITLE
Add inline username save feedback and unify goal text styling

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 const TAB_LABELS = {
   feed: "Everyone's Goals",
@@ -29,19 +29,80 @@ function Sidebar({
 }) {
   const [draftName, setDraftName] = useState(username);
   const [hasHydrated, setHasHydrated] = useState(false);
+  const [saveState, setSaveState] = useState('idle');
+  const [feedback, setFeedback] = useState('');
+  const feedbackTimeoutRef = useRef(null);
 
   useEffect(() => {
     setDraftName(username);
   }, [username]);
 
   useEffect(() => {
+    return () => {
+      if (feedbackTimeoutRef.current) {
+        window.clearTimeout(feedbackTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (feedbackTimeoutRef.current) {
+      window.clearTimeout(feedbackTimeoutRef.current);
+      feedbackTimeoutRef.current = null;
+    }
+    setSaveState('idle');
+    setFeedback('');
+  }, [draftName]);
+
+  useEffect(() => {
     setHasHydrated(true);
   }, []);
 
+  const normalizedUsername = (username || '').trim();
+  const trimmedDraft = draftName.trim();
+  const isDirty = trimmedDraft && trimmedDraft !== normalizedUsername;
+
   const handleSubmit = (event) => {
     event.preventDefault();
-    if (draftName.trim()) {
-      onUsernameSave(draftName);
+    if (!isDirty) {
+      return;
+    }
+
+    if (feedbackTimeoutRef.current) {
+      window.clearTimeout(feedbackTimeoutRef.current);
+      feedbackTimeoutRef.current = null;
+    }
+
+    try {
+      const maybePromise = onUsernameSave(draftName);
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        setSaveState('pending');
+        maybePromise
+          .then(() => {
+            setSaveState('success');
+            setFeedback('Username updated');
+            feedbackTimeoutRef.current = window.setTimeout(() => {
+              setSaveState('idle');
+              setFeedback('');
+              feedbackTimeoutRef.current = null;
+            }, 2400);
+          })
+          .catch(() => {
+            setSaveState('error');
+            setFeedback('Could not save username');
+          });
+      } else {
+        setSaveState('success');
+        setFeedback('Username updated');
+        feedbackTimeoutRef.current = window.setTimeout(() => {
+          setSaveState('idle');
+          setFeedback('');
+          feedbackTimeoutRef.current = null;
+        }, 2400);
+      }
+    } catch (err) {
+      setSaveState('error');
+      setFeedback('Could not save username');
     }
   };
 
@@ -110,17 +171,44 @@ function Sidebar({
       <form className="sidebar-footer" onSubmit={handleSubmit}>
         <label className="username-label">
           Username
-          <input
-            type="text"
-            value={draftName}
-            onChange={(event) => setDraftName(event.target.value)}
-            placeholder="Your display name"
-          />
+          <div className="username-input-row">
+            <input
+              type="text"
+              value={draftName}
+              onChange={(event) => setDraftName(event.target.value)}
+              placeholder="Your display name"
+            />
+            <button
+              type="submit"
+              className="username-save-button"
+              title="Save username"
+              aria-label="Save username"
+              disabled={!isDirty || saveState === 'pending'}
+              aria-busy={saveState === 'pending'}
+            >
+              <svg width="18" height="18" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+                <path
+                  d="M16.707 5.293a1 1 0 0 1 0 1.414l-7.25 7.25a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8.5 11.086l6.543-6.543a1 1 0 0 1 1.414 0z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
         </label>
+        <div
+          className="username-feedback"
+          aria-live={saveState === 'error' ? 'assertive' : 'polite'}
+          role={saveState === 'error' ? 'alert' : 'status'}
+        >
+          {feedback && (
+            <span
+              className={`username-feedback__message username-feedback__message--${saveState}`}
+            >
+              {feedback}
+            </span>
+          )}
+        </div>
         <div className="footer-actions">
-          <button type="submit" className="secondary-button">
-            Save
-          </button>
           <button type="button" className="danger-button" onClick={onLogout}>
             Log out
           </button>

--- a/src/styles.css
+++ b/src/styles.css
@@ -231,6 +231,64 @@ textarea {
   color: var(--c-primary);
 }
 
+.username-input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.username-input-row input {
+  flex: 1 1 auto;
+}
+
+.username-save-button {
+  min-height: 40px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--c-text-2);
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.username-save-button:not(:disabled):hover,
+.username-save-button:not(:disabled):focus-visible {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.username-save-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.username-save-button[aria-busy='true'] {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.username-feedback {
+  min-height: 1.25rem;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.username-feedback__message {
+  display: inline-block;
+  padding-top: 0.25rem;
+}
+
+.username-feedback__message--error {
+  color: #ffd7d7;
+}
+
+.username-feedback__message--success {
+  color: #c7ffe0;
+}
+
 .footer-actions {
   display: flex;
   gap: 0.75rem;
@@ -310,6 +368,11 @@ textarea {
 .goal-text {
   margin: 0.35rem 0 0;
   flex: 1 1 auto;
+  font-size: 1.05rem;
+  font-weight: 500;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .goal-text-row {
@@ -383,6 +446,12 @@ textarea {
   font-size: 0.95rem;
 }
 
+.goal-edit-form textarea {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  font-weight: 500;
+}
+
 .goal-edit-actions {
   display: flex;
   gap: 0.75rem;
@@ -414,6 +483,12 @@ textarea {
 .goal-form label {
   display: grid;
   gap: 0.5rem;
+}
+
+.goal-form textarea {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  font-weight: 500;
 }
 
 .page-empty {


### PR DESCRIPTION
## Summary
- add an inline save button and success message to the sidebar username form for quicker confirmation
- show brief feedback after username updates resolve while keeping the logout action accessible
- align goal text typography and spacing between forms and cards so authored paragraphs stay consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff25c91e883338eb9464f0111a965