### PR TITLE
Improve goal editing UX and add deadline time selection

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -68,6 +68,14 @@ textarea {
   resize: vertical;
 }
 
+input[type='checkbox'] {
+  width: 20px;
+  height: 20px;
+  min-height: 0;
+  padding: 0;
+  border-radius: 4px;
+}
+
 .app-shell {
   display: flex;
   flex-direction: column;
@@ -452,6 +460,15 @@ textarea {
   font-weight: 500;
 }
 
+.goal-edit-textarea {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 12rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  font-weight: 500;
+}
+
 .goal-edit-actions {
   display: flex;
   gap: 0.75rem;
@@ -489,6 +506,18 @@ textarea {
   font-size: 1.05rem;
   line-height: 1.6;
   font-weight: 500;
+  min-height: 12rem;
+}
+
+.deadline-inputs {
+  display: grid;
+  gap: 0.5rem;
+}
+
+@media (min-width: 480px) {
+  .deadline-inputs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .page-empty {


### PR DESCRIPTION
## Summary
- integrate goal text editing directly into the card header and enlarge the editor for easier updates
- add time selection alongside deadline dates and display formatted deadlines with time
- adjust textarea and checkbox styling to improve layout and alignment of goal forms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff878b6988333bc762d5bcb040267