### PR TITLE
Fix public goal deletion rules and improve goal editing UI

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,8 +10,11 @@ service cloud.firestore {
     }
     match /public_goals/{goalId} {
       allow read: if authed();
-      allow create, update, delete: if authed()
+      allow create: if authed() && request.resource.data.authorUid == request.auth.uid;
+      allow update: if authed()
+        && resource.data.authorUid == request.auth.uid
         && request.resource.data.authorUid == request.auth.uid;
+      allow delete: if authed() && resource.data.authorUid == request.auth.uid;
     }
   }
 }

--- a/src/components/GoalCard.jsx
+++ b/src/components/GoalCard.jsx
@@ -82,6 +82,16 @@ function GoalCard({ goal, editable = false, onSave, onDelete }) {
     }
   };
 
+  const handleStartEdit = () => {
+    setForm(mapGoalToForm(goal));
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setForm(mapGoalToForm(goal));
+    setIsEditing(false);
+  };
+
   const handleSave = () => {
     if (!onSave) return;
     const payload = {
@@ -101,6 +111,11 @@ function GoalCard({ goal, editable = false, onSave, onDelete }) {
 
   const typeLabel = TYPE_LABELS[goal.type] || 'Goal';
   const statusLabel = STATUS_LABELS[goal.status] || goal.status;
+
+  const showViewMeta = !isEditing || !editable;
+  const showCreatedMeta = Boolean(createdAtText);
+  const showAuthorMeta = Boolean(goal.authorName);
+  const shouldRenderMeta = showViewMeta || showCreatedMeta || showAuthorMeta;
 
   return (
     <article className={`goal-card ${goal.status}`}>
@@ -141,27 +156,33 @@ function GoalCard({ goal, editable = false, onSave, onDelete }) {
             )}
           </div>
         </div>
-        {editable && (
+        {editable && !isEditing && (
           <button
             type="button"
             className="secondary-button"
-            onClick={() => setIsEditing((prev) => !prev)}
+            onClick={handleStartEdit}
           >
-            {isEditing ? 'Cancel' : 'Edit'}
+            Edit
           </button>
         )}
       </header>
-      <div className="goal-meta">
-        <span>Deadline: {deadlineText}</span>
-        {deadlineDate && countdownLabel && (
-          <span className="goal-countdown" aria-live="polite">
-            {countdownLabel}
-          </span>
-        )}
-        <span>Status: {statusLabel}</span>
-        {createdAtText && <span>Created: {createdAtText}</span>}
-        {goal.authorName && <span>By: {goal.authorName}</span>}
-      </div>
+      {shouldRenderMeta && (
+        <div className="goal-meta">
+          {showViewMeta && (
+            <>
+              <span>Deadline: {deadlineText}</span>
+              {deadlineDate && countdownLabel && (
+                <span className="goal-countdown" aria-live="polite">
+                  {countdownLabel}
+                </span>
+              )}
+              <span>Status: {statusLabel}</span>
+            </>
+          )}
+          {showCreatedMeta && <span>Created: {createdAtText}</span>}
+          {showAuthorMeta && <span>By: {goal.authorName}</span>}
+        </div>
+      )}
       {editable && isEditing && (
         <div className="goal-edit-form">
           <label>
@@ -209,6 +230,9 @@ function GoalCard({ goal, editable = false, onSave, onDelete }) {
           <div className="goal-edit-actions">
             <button type="button" className="primary-button" onClick={handleSave}>
               Save
+            </button>
+            <button type="button" className="secondary-button" onClick={handleCancel}>
+              Cancel
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary
- tighten public goal Firestore rules so only authors can create, update, or delete their entries and allow deletions to succeed
- adjust goal card editing flow to hide duplicate metadata, reset forms when editing begins/cancels, and move the Cancel action beside Save/Delete for better mobile UX

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfff5721808333907f6bc61cd59e44