### PR TITLE
Refine desktop layout and relocate goal filters

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,7 +35,8 @@ function App() {
   const [user, setUser] = useState(null);
   const [profile, setProfile] = useState(null);
   const [activeTab, setActiveTab] = useState(TABS.FEED);
-  const [typeFilter, setTypeFilter] = useState('all');
+  const [publicFilter, setPublicFilter] = useState('all');
+  const [myFilter, setMyFilter] = useState('all');
   const [publicGoals, setPublicGoals] = useState([]);
   const [publicLoading, setPublicLoading] = useState(true);
   const [myGoals, setMyGoals] = useState([]);
@@ -128,16 +129,16 @@ function App() {
   }, [user]);
 
   const filteredPublicGoals = useMemo(() => {
-    if (typeFilter === 'all') return publicGoals;
-    const typeValue = typeFilter === 'one' ? 'one' : typeFilter;
+    if (publicFilter === 'all') return publicGoals;
+    const typeValue = publicFilter === 'one' ? 'one' : publicFilter;
     return publicGoals.filter((goal) => goal.type === typeValue);
-  }, [publicGoals, typeFilter]);
+  }, [publicGoals, publicFilter]);
 
   const filteredMyGoals = useMemo(() => {
-    if (typeFilter === 'all') return myGoals;
-    const typeValue = typeFilter === 'one' ? 'one' : typeFilter;
+    if (myFilter === 'all') return myGoals;
+    const typeValue = myFilter === 'one' ? 'one' : myFilter;
     return myGoals.filter((goal) => goal.type === typeValue);
-  }, [myGoals, typeFilter]);
+  }, [myGoals, myFilter]);
 
   const handleCreateGoal = async ({ text, type, deadline, isPublic }) => {
     if (!user || creatingGoal) return;
@@ -400,9 +401,6 @@ function App() {
       <Sidebar
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        filter={typeFilter}
-        onFilterChange={setTypeFilter}
-        filters={FILTERS}
         username={sidebarUsername}
         onUsernameSave={handleUsernameChange}
         onLogout={handleLogout}
@@ -414,13 +412,19 @@ function App() {
 
       <main className="content-area">
         {activeTab === TABS.FEED && (
-          <Feed goals={filteredPublicGoals} loading={publicLoading} />
+          <Feed
+            goals={filteredPublicGoals}
+            loading={publicLoading}
+            filter={publicFilter}
+            onFilterChange={setPublicFilter}
+            filters={FILTERS}
+          />
         )}
         {activeTab === TABS.NEW && (
           <NewGoal
             onCreate={handleCreateGoal}
             submitting={creatingGoal}
-            defaultType={typeFilter}
+            defaultType="one"
           />
         )}
         {activeTab === TABS.MINE && (
@@ -429,6 +433,9 @@ function App() {
             loading={myGoalsLoading}
             onUpdate={handleUpdateGoal}
             onDelete={handleDeleteGoal}
+            filter={myFilter}
+            onFilterChange={setMyFilter}
+            filters={FILTERS}
           />
         )}
       </main>

--- a/src/components/FilterTabs.jsx
+++ b/src/components/FilterTabs.jsx
@@ -1,0 +1,29 @@
+const FILTER_LABELS = {
+  all: 'All',
+  one: 'One-Time',
+  daily: 'Daily',
+  weekly: 'Weekly',
+};
+
+function FilterTabs({ value, onChange, filters = ['all', 'one', 'daily', 'weekly'] }) {
+  return (
+    <div className="filter-tabs" role="group" aria-label="Filter goals by cadence">
+      {filters.map((key) => {
+        const isActive = value === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            className={`filter-tab${isActive ? ' active' : ''}`}
+            onClick={() => onChange(key)}
+            aria-pressed={isActive}
+          >
+            {FILTER_LABELS[key] || key}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default FilterTabs;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -6,19 +6,9 @@ const TAB_LABELS = {
   mine: 'My Goals',
 };
 
-const FILTER_LABELS = {
-  all: 'All',
-  one: 'One-Time',
-  daily: 'Daily',
-  weekly: 'Weekly',
-};
-
 function Sidebar({
   activeTab,
   onTabChange,
-  filter,
-  onFilterChange,
-  filters,
   username,
   onUsernameSave,
   onLogout,
@@ -156,18 +146,6 @@ function Sidebar({
           </button>
         ))}
       </nav>
-      <div className="filter-chips">
-        {filters.map((key) => (
-          <button
-            key={key}
-            type="button"
-            className={`chip ${filter === key ? 'active' : ''}`}
-            onClick={() => onFilterChange(key)}
-          >
-            {FILTER_LABELS[key]}
-          </button>
-        ))}
-      </div>
       <form className="sidebar-footer" onSubmit={handleSubmit}>
         <label className="username-label">
           Username

--- a/src/pages/Feed.jsx
+++ b/src/pages/Feed.jsx
@@ -1,10 +1,14 @@
 import GoalCard from '../components/GoalCard.jsx';
+import FilterTabs from '../components/FilterTabs.jsx';
 
-function Feed({ goals, loading }) {
+function Feed({ goals, loading, filter, onFilterChange, filters }) {
   return (
     <section className="page">
       <header className="page-header">
-        <h1>Everyone's Goals</h1>
+        <div className="page-header__title-row">
+          <h1>Everyone's Goals</h1>
+          <FilterTabs value={filter} onChange={onFilterChange} filters={filters} />
+        </div>
         <p>See what the crew is committing to this cycle.</p>
       </header>
       {loading ? (
@@ -12,7 +16,7 @@ function Feed({ goals, loading }) {
       ) : goals.length === 0 ? (
         <p className="page-empty">No public goals yet. Be the first to share!</p>
       ) : (
-        <div className="goal-grid">
+        <div className="goal-grid goal-grid--single">
           {goals.map((goal) => (
             <GoalCard key={goal.id} goal={goal} />
           ))}

--- a/src/pages/MyGoals.jsx
+++ b/src/pages/MyGoals.jsx
@@ -1,10 +1,14 @@
 import GoalCard from '../components/GoalCard.jsx';
+import FilterTabs from '../components/FilterTabs.jsx';
 
-function MyGoals({ goals, loading, onUpdate, onDelete }) {
+function MyGoals({ goals, loading, onUpdate, onDelete, filter, onFilterChange, filters }) {
   return (
     <section className="page">
       <header className="page-header">
-        <h1>My Goals</h1>
+        <div className="page-header__title-row">
+          <h1>My Goals</h1>
+          <FilterTabs value={filter} onChange={onFilterChange} filters={filters} />
+        </div>
         <p>Track, adjust, and broadcast your personal commitments.</p>
       </header>
       {loading ? (

--- a/src/styles.css
+++ b/src/styles.css
@@ -197,31 +197,6 @@ input[type='checkbox'] {
   border-color: var(--c-accent);
 }
 
-.filter-chips {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.chip {
-  border-radius: 999px;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  color: inherit;
-  padding: 0.5rem 1.25rem;
-  font-size: 0.95rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.chip.active,
-.chip:hover {
-  background: var(--c-text-2);
-  color: var(--c-primary);
-  border-color: var(--c-text-2);
-}
-
 .sidebar-footer {
   margin-top: auto;
   display: grid;
@@ -337,15 +312,61 @@ input[type='checkbox'] {
   font-size: 2rem;
 }
 
+.page-header__title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .page-header p {
   margin: 0.5rem 0 0;
   color: rgba(10, 10, 10, 0.65);
+}
+
+.filter-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-tab {
+  border: none;
+  border-radius: 999px;
+  background: var(--c-primary);
+  color: var(--c-text-2);
+  padding: 0.45rem 1.2rem;
+  font-size: 0.95rem;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.filter-tab:not(.active):hover,
+.filter-tab:not(.active):focus-visible {
+  background: #144c7f;
+}
+
+.filter-tab.active {
+  background: var(--c-accent);
+}
+
+.filter-tab:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
 }
 
 .goal-grid {
   display: grid;
   gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.goal-grid--single {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .goal-card {
@@ -388,6 +409,7 @@ input[type='checkbox'] {
   align-items: flex-start;
   gap: 0.35rem;
   flex-wrap: nowrap;
+  min-width: 0;
 }
 
 .goal-text--collapsed {
@@ -396,6 +418,11 @@ input[type='checkbox'] {
   -webkit-line-clamp: 1;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.goal-text {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .goal-text--expanded {
@@ -467,6 +494,7 @@ input[type='checkbox'] {
   font-size: 1.05rem;
   line-height: 1.6;
   font-weight: 500;
+  min-width: 0;
 }
 
 .goal-edit-actions {
@@ -652,7 +680,10 @@ input[type='checkbox'] {
   }
 
   .sidebar {
-    min-height: 100vh;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
   }
 
   .content-area {


### PR DESCRIPTION
## Summary
- keep the desktop sidebar fixed to the viewport while editing long goals
- move the cadence filters into the Everyone's Goals and My Goals headers with refreshed styling
- ensure public goal cards stack in a single column and tighten goal card overflow handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00443acac83338c9761c357cf44b6